### PR TITLE
Fixed docker-compose build context for chat, hub, and logger

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     ports:
       - "5001:80"
   chat:
-    build: ./src/chat
+    build:
+      context: ./src
+      dockerfile: chat/Dockerfile
     restart: always
     ports:
       - "5050:80"
@@ -32,14 +34,18 @@ services:
       - api
       - hub
   hub:
-    build: ./src/hub
+    build:
+      context: ./src
+      dockerfile: hub/Dockerfile
     restart: always
     ports:
       - "5060:80"
     expose:
       - "5060"
   logger:
-    build: ./src/logger
+    build:
+      context: ./src
+      dockerfile: logger/Dockerfile
     restart: always
     depends_on:
       - hub

--- a/io.code-workspace
+++ b/io.code-workspace
@@ -1,31 +1,31 @@
 {
 	"folders": [
 		{
-			"path": "src\\admin"
+			"path": "src/admin"
 		},
 		{
-			"path": "src\\api"
+			"path": "src/api"
 		},
 		{
-			"path": "src\\chat"
+			"path": "src/chat"
 		},
 		{
-			"path": "src\\chron"
+			"path": "src/chron"
 		},
 		{
-			"path": "src\\hub"
+			"path": "src/hub"
 		},
 		{
-      "path": "src\\logger"
+      		"path": "src/logger"
 		},
 		{
-			"path": "src\\overlay"
+			"path": "src/overlay"
 		},
 		{
-			"path": "src\\user"
+			"path": "src/user"
 		},
 		{
-			"path": "src\\models"
+			"path": "src/models"
 		},
 		{
 			"path": "."

--- a/src/chat/Dockerfile
+++ b/src/chat/Dockerfile
@@ -4,8 +4,8 @@ ARG BUILDVERSION=0.0.0
 
 WORKDIR /app
 
-COPY . .
-COPY package*.json ./
+COPY ./chat .
+COPY ./models ./src
 
 RUN npm install
 

--- a/src/hub/Dockerfile
+++ b/src/hub/Dockerfile
@@ -4,8 +4,8 @@ ARG BUILDVERSION=0.0.0
 
 WORKDIR /app
 
-COPY . .
-COPY package*.json ./
+COPY ./hub .
+COPY ./models ./src
 
 RUN npm install
 
@@ -14,4 +14,4 @@ RUN npm run build
 
 EXPOSE 80
 
-CMD [ "npm", "start"]
+CMD [ "npm", "start" ]

--- a/src/logger/Dockerfile
+++ b/src/logger/Dockerfile
@@ -4,8 +4,8 @@ ARG BUILDVERSION=0.0.0
 
 WORKDIR /app
 
-COPY . .
-COPY package*.json ./
+COPY ./logger .
+COPY ./models ./src
 
 RUN npm install
 
@@ -14,4 +14,4 @@ RUN npm run build
 
 EXPOSE 80
 
-CMD [ "npm", "start"]
+CMD [ "npm", "start" ]

--- a/src/logger/package-lock.json
+++ b/src/logger/package-lock.json
@@ -42,6 +42,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
+      "dev": true
+    },
     "@types/mongodb": {
       "version": "3.1.28",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.28.tgz",

--- a/src/logger/package.json
+++ b/src/logger/package.json
@@ -24,12 +24,14 @@
   },
   "devDependencies": {
     "@types/dotenv": "^6.1.1",
+    "@types/lodash": "^4.14.134",
     "@types/mongodb": "^3.1.28",
     "@types/node": "^12.0.2",
     "@types/socket.io": "^2.1.2",
     "@types/socket.io-client": "^1.4.32",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.3.0",
+    "lodash": "^4.17.11",
     "tslint": "^5.16.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^3.4.5"

--- a/src/logger/src/logger.ts
+++ b/src/logger/src/logger.ts
@@ -1,6 +1,7 @@
 import mongodb = require('mongodb');
 import io from 'socket.io-client';
 import { config, log } from './common';
+import _ from 'lodash';
 
 import {
   IUserInfo,


### PR DESCRIPTION
## TLDR; It's alive!

In order to allow the ./models to be included in the chat, hub, and logger services, we needed to change the context used when running docker-compose. Additionally, because we changed the context for which docker-compose is used, the Dockerfile's for each service also needed to be updated to `copy` from the relative location from the 'context'.

Finally, in order for the logger service to build, I had to add `lodash` to the npm packages and import it into the `logger.ts` file.

![bitmoji](https://render.bitstrips.com/v2/cpanel/21759482-c054-4dc5-aaef-e9ce15cf7e3a-b427cfda-a7f5-497f-a483-1061dc3d44a5-v1.png?transparent=1&palette=1&width=246)

