### PR TITLE
Use pinned node docker image version

### DIFF
--- a/src/admin/Dockerfile
+++ b/src/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/chat/Dockerfile
+++ b/src/chat/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/chron/Dockerfile
+++ b/src/chron/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/hub/Dockerfile
+++ b/src/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/logger/Dockerfile
+++ b/src/logger/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/overlay/Dockerfile
+++ b/src/overlay/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/stream-notes/Dockerfile
+++ b/src/stream-notes/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/user/Dockerfile
+++ b/src/user/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 

--- a/src/webhooks/Dockerfile
+++ b/src/webhooks/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS build
+FROM node:12.6.0-alpine
 
 ARG BUILDVERSION=0.0.0
 


### PR DESCRIPTION
This uses the alpine build image, and pins to the latest stable 12.6.0 release.