### PR TITLE
Minor refactor to separate user commands

### DIFF
--- a/src/chat/src/commands/basic-commands.ts
+++ b/src/chat/src/commands/basic-commands.ts
@@ -1,6 +1,6 @@
 import { ChatUserstate } from 'tmi.js';
 
-import { isMod, isBroadcaster, get } from '@shared/common';
+import { isMod, isBroadcaster } from '@shared/common';
 
 export const websiteCommand = (
   message: string,

--- a/src/chat/src/commands/basic-commands.ts
+++ b/src/chat/src/commands/basic-commands.ts
@@ -293,29 +293,3 @@ export const liveCodersCommand = (
 
   return false;
 };
-
-export const updateUserCommand = async (
-  message: string,
-  user: ChatUserstate,
-  twitchChatFunc: (message: string) => void
-): Promise<boolean> => {
-  if (message === undefined || message.length === 0) {
-    return false;
-  }
-
-  const lowerMessage = message.toLocaleLowerCase().trim();
-  const firstWord = lowerMessage.split(' ')[0];
-
-  if (firstWord !== '!update') {
-    return false;
-  }
-
-  // Call the user service to update user
-  const url = `http://user/update/${user.username}/true`;
-
-  await get(url).then((updatedUser: any) => {
-    return updatedUser;
-  });
-
-  return true;
-};

--- a/src/chat/src/commands/index.ts
+++ b/src/chat/src/commands/index.ts
@@ -3,5 +3,6 @@ import * as BasicCommands from './basic-commands';
 import * as CandleCommands from './candle/candle-commands';
 import * as StreamCommands from './stream-commands';
 import * as NoteCommands from './note-commands';
+import * as UserCommands from './user-commands';
 
-export { AVCommands, BasicCommands, CandleCommands, NoteCommands, StreamCommands };
+export { AVCommands, BasicCommands, CandleCommands, NoteCommands, StreamCommands, UserCommands };

--- a/src/chat/src/commands/user-commands.ts
+++ b/src/chat/src/commands/user-commands.ts
@@ -1,0 +1,44 @@
+import { ChatUserstate } from 'tmi.js';
+
+import { get } from '@shared/common';
+
+export const updateUserCommand = async (
+    message: string,
+    user: ChatUserstate,
+    twitchChatFunc: (message: string) => void
+  ): Promise<boolean> => {
+    if (message === undefined || message.length === 0) {
+      return false;
+    }
+  
+    const lowerMessage = message.toLocaleLowerCase().trim();
+    const firstWord = lowerMessage.split(' ')[0];
+  
+    if (firstWord !== '!update') {
+      return false;
+    }
+  
+    // Call the user service to update user
+    const url = `http://user/update/${user.username}/true`;
+  
+    await get(url).then((updatedUser: any) => {
+        if (updatedUser && updatedUser != undefined)
+        {
+            if (twitchChatFunc) {
+                twitchChatFunc(
+                  `User ${user.username} has been successfully updated`
+                );
+              }
+              return true;
+        } else {
+            if (twitchChatFunc) {
+                twitchChatFunc(
+                  `There was an issue while updating ${user.username}`
+                );
+              }
+              return true;
+        }
+    });
+    
+    return true;
+  };

--- a/src/chat/src/commands/user-commands.ts
+++ b/src/chat/src/commands/user-commands.ts
@@ -1,12 +1,14 @@
 import { ChatUserstate } from 'tmi.js';
 
 import { get } from '@shared/common';
+import { IUserInfo } from '@shared/models';
+
 
 export const updateUserCommand = async (
     message: string,
     user: ChatUserstate,
     twitchChatFunc: (message: string) => void
-  ): Promise<boolean> => {
+  ): Promise<IUserInfo | boolean> => {
     if (message === undefined || message.length === 0) {
       return false;
     }
@@ -20,7 +22,7 @@ export const updateUserCommand = async (
   
     // Call the user service to update user
     const url = `http://user/update/${user.username}/true`;
-  
+    
     await get(url).then((updatedUser: any) => {
         if (updatedUser && updatedUser != undefined)
         {
@@ -29,16 +31,14 @@ export const updateUserCommand = async (
                   `User ${user.username} has been successfully updated`
                 );
               }
-              return true;
+              return updatedUser;
         } else {
             if (twitchChatFunc) {
                 twitchChatFunc(
                   `There was an issue while updating ${user.username}`
                 );
               }
-              return true;
         }
     });
-    
     return true;
   };

--- a/src/chat/src/twitch-chat.ts
+++ b/src/chat/src/twitch-chat.ts
@@ -382,13 +382,13 @@ export class TwitchChat {
           chatMessageArg.userInfo = updatedUser;
         }
 
-        this.emitMessage(SocketIOEvents.OnChatMessage, chatMessageArg);
         break;
       }
     }
 
     //Go ahead and emit message to hub before processing the rest of the commands
     this.emitMessage(SocketIOEvents.OnChatMessage, chatMessageArg);
+    
     if (!handledByCommand) {
       for (const basicCommand of Object.values(BasicCommands)) {
         handledByCommand = await basicCommand(

--- a/src/user/src/user.ts
+++ b/src/user/src/user.ts
@@ -127,9 +127,16 @@ export class User {
     user.lastUpdated = new Date().toISOString();
 
     user = await this.userDb.saveUserInfo(user);
-    this.users[user.login] = user;
 
-    log('info', `Updated ${username} from api`);
+    //Provide some error handling
+    if (user)
+    {
+      this.users[user.login] = user;
+      log('info', `Updated ${username} from api`);
+    } else {
+      user = this.users[user.login];
+      log('error', `Error while updating ${username} in DB`);
+    }
 
     return user;
   };

--- a/src/user/src/user.ts
+++ b/src/user/src/user.ts
@@ -133,8 +133,8 @@ export class User {
     {
       this.users[user.login] = user;
       log('info', `Updated ${username} from api`);
-    } else {
-      user = this.users[user.login];
+    } else if (existingUser) {
+      user = this.users[existingUser.login];
       log('error', `Error while updating ${username} in DB`);
     }
 


### PR DESCRIPTION
This will have to be looked over and tested as my JS and TS is a bit rusty and I don't have the environment fully setup to run the project right now.

List of changes:

- Refactored updateUserCommand to its own user-commands file to aid in future expansion of commands (spoke of being able to set twitter/github usernames)
- Added notification to user in channel of successful or unsuccessful update
- Renamed saveUser() to updateAndGetUser() to add clarity to what the function does
- Added some error handling to the update function in user.ts.

Previously in user.ts if there was an error updating the document in mongoDB, the cache for that user would have been overwritten with undefined. Added check to see if a document was actually returned. If not, set user back to what is in cache and return the cached user.