### PR TITLE
Wrap last follower call in case of no followers

### DIFF
--- a/src/chron/src/chron.ts
+++ b/src/chron/src/chron.ts
@@ -64,23 +64,25 @@ export class Chron {
     const resp = await get(url).then((data: any) => data);
 
     const followerCount: number = resp.total;
-
-    const lastFollower: IUserInfo | undefined = await this.getUser(
-      resp.data[0].from_name
-    );
-
+      
     const followerCountEventArg: IFollowerCountEventArg = {
       followers: followerCount
     };
 
     this.emitMessage(SocketIOEvents.FollowerCountChanged, followerCountEventArg);
 
-    if (lastFollower) {
-      const lastFollowerEventArg: ILastUserEventArg = {
-        userInfo: lastFollower
-      };
+    if (resp.total > 0 && resp.data[0].from_name) {
+      const lastFollower: IUserInfo | undefined = await this.getUser(
+        resp.data[0].from_name
+      );
 
-      this.emitMessage(SocketIOEvents.LastFollowerUpdated, lastFollowerEventArg);
+      if (lastFollower) {
+        const lastFollowerEventArg: ILastUserEventArg = {
+          userInfo: lastFollower
+        };
+  
+        this.emitMessage(SocketIOEvents.LastFollowerUpdated, lastFollowerEventArg);
+      }
     }
     return;
   };


### PR DESCRIPTION
I noticed when setting up the environment to test changes that I would get errors every time chron tried to check for the last followers. 

Wrapped the last follower call in an if statement to stop from trying to get the last follower details if the follower count is 0.

Hopefully wouldn't be an issue for a streamer too long, ;)