### PR TITLE
Fixed port for debugging repo, mapped wrong object in response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ typings/
 
 # dotenv environment variables file
 .env
+
+.vs/

--- a/io.code-workspace
+++ b/io.code-workspace
@@ -110,7 +110,7 @@
 				"type": "node",
 				"request": "attach",
 				"name": "Attach: Repo",
-				"port": 9226,
+				"port": 9229,
 				"restart": true,
 				"localRoot": "${workspaceFolder:repo}",
 				"remoteRoot": "/app/repo"

--- a/services/chron/src/chron.ts
+++ b/services/chron/src/chron.ts
@@ -72,7 +72,7 @@ export class Chron {
   }
 
   private refreshRepos = async (): Promise<void> => {
-    const resp: IGitHubRepo[] = await get(this.repoUrl).then((data: any) => data as IGitHubRepo[]);
+    const resp: IGitHubRepo[] = await get(this.repoUrl).then((response: any) => response.data as IGitHubRepo[]);
     if (resp.length > 0) {
       const url = `http://repo/refresh`;
       await post(url, resp);


### PR DESCRIPTION
Finished watching the stream via VOD and noticed the port didn't get changed in the workspace launch config. When testing I noticed it was casting the response object instead of response.data, so length was always undefined and the update wasn't called.

Also added .vs to the .gitignore so I didn't accidentally push it at some point.