### PR TITLE
upped the response size limit

### DIFF
--- a/services/api/src/api.ts
+++ b/services/api/src/api.ts
@@ -15,7 +15,7 @@ export class API {
   private kraken: Kraken;
 
   constructor() {
-    this.app = express.default().use(express.json());
+    this.app = express.default().use(express.json({limit: '50mb'}));
     this.http = new Server(this.app);
     this.helix = new Helix();
     this.github = new Github();
@@ -135,6 +135,17 @@ export class API {
 
       const payload: any = await this.github.getRepos();
       res.send(payload);
+    });
+
+    //Get list of repos for user
+    this.app.get('/repos/:username', async (req, res) => {
+      log('info', `route: /repos called`);
+      if (req.params.username) {
+        const payload: any = await this.github.getReposForUser(req.params.username);
+        res.send(payload);
+      } else {
+        res.status(404).send("username parameter is required");
+      }
     });
     
     //Get issues for repo

--- a/services/api/src/github.ts
+++ b/services/api/src/github.ts
@@ -19,6 +19,14 @@ export class Github {
     });
   }
 
+  public async getReposForUser(user: string, type: any = "owner", sort: any = "updated"): Promise<any> {
+    return this.octokit.repos.listForUser({
+      username: user,
+      type: type,
+      sort: sort
+    });
+  }
+
   public async getIssuesForRepo(repo: string): Promise<any> {
     return this.octokit.issues.listForRepo({
       owner: this.githubUsername,

--- a/services/repo/src/repo.ts
+++ b/services/repo/src/repo.ts
@@ -14,7 +14,7 @@ export class Repo {
   private repoDb: RepoDb;
 
   constructor() {
-    this.app = express.default().use(express.json());
+    this.app = express.default().use(express.json({limit: '50mb'}));
     this.http = new Server(this.app);
     this.repoDb = new RepoDb();
 


### PR DESCRIPTION
Upped default limit to 50mb to ensure we don't get an entity too large error. If responses go over 50mb (and probably well before that) we need to rethink the strategy, maybe include pagination.

Also added getReposForUser and associated endpoint, no current need but makes testing/getting a response to see what's included a bit easier.